### PR TITLE
fix: Log out when JWT is expired or malformed

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -421,7 +421,10 @@ class App extends AsyncComponent<RouteComponentProps, AppState> {
      * @returns The expiry time.
      */
     private getTokenExpiry(token: string) {
-        const payload = token.split(".")[1];
+        const [header, payload, signature] = token.split(".");
+        if (header.length !== 43 || signature.length !== 43) {
+            throw new Error("Malformed JWT");
+        }
         const decodedToken = window.atob(payload);
         const parsedToken = JSON.parse(decodedToken);
         const expiryTimestamp = parsedToken.exp * 1000;


### PR DESCRIPTION
# Description of change

Closes https://github.com/iotaledger/wasp-dashboard/issues/81

When JWT is malformed or expired, it will log out

## Type of change

- Bug fix

## How the change has been tested

-  Edit your JWT to be wrong
-  Refresh the dashboard
-  A wrong JWT should logout

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
