### PR TITLE
fix: Remove :9090

### DIFF
--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -6,5 +6,5 @@ import { Environment } from "../environment";
  * @returns The formatted URL.
  */
 export function formatEVMJSONRPCUrl(chainID: string): string {
-    return `${Environment.WaspApiUrl}:9090/chain/${chainID}/evm/jsonrpc`;
+    return `${Environment.WaspApiUrl}/chain/${chainID}/evm/jsonrpc`;
 }


### PR DESCRIPTION
Closes https://github.com/iotaledger/wasp-dashboard/issues/178

# Description of change

Removes harcoded 9090 port from the EVM JSON RPC URL formatter

## Type of change

- Bug fix

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
