### PR TITLE
fix: Sync the client service before publishing any auth state change

### DIFF
--- a/src/lib/classes/services/authService.ts
+++ b/src/lib/classes/services/authService.ts
@@ -1,5 +1,5 @@
 import { Environment } from "../../../environment";
-import { ServiceFactory } from "../../classes";
+import { ServiceFactory, WaspClientService } from "../../classes";
 import { decodeJWTPayload } from "../../utils/jwt";
 import { FetchHelper } from "../helpers";
 import { EventAggregator } from "./eventAggregator";
@@ -10,6 +10,11 @@ import { LocalStorageService } from "./localStorageService";
  */
 export class AuthService {
     public static readonly ServiceName = "AuthService";
+
+    /**
+     * The client service.
+     */
+    private readonly _waspClientService: WaspClientService;
 
     /**
      * The storage service.
@@ -31,6 +36,7 @@ export class AuthService {
      */
     constructor() {
         this._jwt = undefined;
+        this._waspClientService = ServiceFactory.get<WaspClientService>(WaspClientService.ServiceName);
         this._storageService = ServiceFactory.get<LocalStorageService>(LocalStorageService.ServiceName);
 
         if (document.cookie) {
@@ -95,6 +101,7 @@ export class AuthService {
             if (response.jwt) {
                 this._jwt = `Bearer ${response.jwt}`;
                 this._storageService.save<string>("dashboard-jwt", this._jwt);
+                this._waspClientService.initialize();
                 EventAggregator.publish("auth-state", true);
             }
         } catch (err) {
@@ -111,6 +118,7 @@ export class AuthService {
         if (this._jwt) {
             this._storageService.remove("dashboard-jwt");
             this._jwt = undefined;
+            this._waspClientService.initialize();
             EventAggregator.publish("auth-state", false);
         }
     }

--- a/src/lib/classes/services/waspClientService.ts
+++ b/src/lib/classes/services/waspClientService.ts
@@ -1,5 +1,5 @@
 import { Environment } from "../../../environment";
-import { EventAggregator, ServiceFactory, LocalStorageService } from "../../classes";
+import { ServiceFactory, LocalStorageService } from "../../classes";
 import {
     UsersApi,
     NodeApi,
@@ -26,10 +26,6 @@ export class WaspClientService {
 
     constructor() {
         this.initialize();
-
-        EventAggregator.subscribe("auth-state", "waspClient", isLoggedIn => {
-            this.initialize();
-        });
     }
 
     public initialize() {


### PR DESCRIPTION
Closes https://github.com/iotaledger/wasp-dashboard/issues/249
# Description of change

The client service used to listen to any auth change and then proceed to reinitialize itself. This was causing an issue as by the time other components listening to any auth change, tried to use the client, it wasn't initialized yet, causing for example to not show any peer in the home view.

I fixed this by re-initializing the client service from the auth service directly, just before publishing any auth change.

## Type of change

- Bug fix

## How the change has been tested

1. Log out
2. Reload website
3. Log in
4. Check if there is any peer in the peer list from the Home view

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code