### PR TITLE
feat: Highlight sidebar button of Home in nested routes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -235,6 +235,7 @@ class App extends Component<object, AppState> {
                 label: "Home",
                 icon: <HomeIcon />,
                 route: "/",
+                extraMatchingRoutes: ["/chains"],
                 hidden: !this.state.isLoggedIn,
             },
             {

--- a/src/app/components/NavPanel.tsx
+++ b/src/app/components/NavPanel.tsx
@@ -38,33 +38,44 @@ function NavPanel(props: NavPanelProps) {
             </Link>
 
             <div className="nav-panel-middle">
-                {props.middle.map(b => (
-                    <React.Fragment key={b.label}>
-                        {!b.hidden && b.route && (
-                            <Link
-                                to={b.route}
-                                className={classNames("nav-panel-button", {
-                                    "nav-panel-button-selected":
-                                        (b.route.length > 1 && location.pathname.startsWith(b.route)) ||
-                                        b.route === location.pathname,
-                                })}
-                            >
-                                {b.icon}
-                                <span className="nav-panel-button-label">{b.label}</span>
-                            </Link>
-                        )}
-                        {!b.hidden && b.function && (
-                            <button
-                                type="button"
-                                onClick={() => b.function?.()}
-                                className={classNames("nav-panel-button")}
-                            >
-                                {b.icon}
-                                <span className="nav-panel-button-label">{b.label}</span>
-                            </button>
-                        )}
-                    </React.Fragment>
-                ))}
+                {props.middle.map(b => {
+                    if (b.hidden) {
+return null;
+}
+
+                    const routeMatches =
+                        b.route === location.pathname ||
+                        (b.route ? b.route?.length > 1 && location.pathname.startsWith(b.route) : false);
+                    const extraRoutesMatch = b.extraMatchingRoutes?.some(route =>
+                        location.pathname.startsWith(route),
+                    );
+
+                    return (
+                        <React.Fragment key={b.label}>
+                            {b.route && (
+                                <Link
+                                    to={b.route}
+                                    className={classNames("nav-panel-button", {
+                                        "nav-panel-button-selected": routeMatches || extraRoutesMatch,
+                                    })}
+                                >
+                                    {b.icon}
+                                    <span className="nav-panel-button-label">{b.label}</span>
+                                </Link>
+                            )}
+                            {b.function && (
+                                <button
+                                    type="button"
+                                    onClick={() => b.function?.()}
+                                    className={classNames("nav-panel-button")}
+                                >
+                                    {b.icon}
+                                    <span className="nav-panel-button-label">{b.label}</span>
+                                </button>
+                            )}
+                        </React.Fragment>
+                    );
+                })}
             </div>
 
             <div className="nav-panel-end">

--- a/src/app/components/NavPanelProps.ts
+++ b/src/app/components/NavPanelProps.ts
@@ -18,6 +18,10 @@ export interface NavPanelProps {
          */
         route?: string;
         /**
+         * Extra matching routes for the button.
+         */
+        extraMatchingRoutes?: string[];
+        /**
          * The function to trigger for the button.
          */
         function?: () => void;


### PR DESCRIPTION
Closes https://github.com/iotaledger/wasp-dashboard/issues/314
# Description of change

- Refactored a bit the code of `NavPanel`
- Added a new `extraMatchingRoutes` for the middle buttons, this will allow to match a certain button in nested routes that are not part of his main route, like Home (`/`) also matching Chains (`/chains`).

## Type of change

- Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code