### PR TITLE
fix: Fix Block explorer and account tabs

### DIFF
--- a/src/app/components/ChainNavbar.tsx
+++ b/src/app/components/ChainNavbar.tsx
@@ -20,7 +20,11 @@ export default function ChainNavbar({ chainID, block }: ChainNavbarProps) {
     const chainURL = `/chains/${chainID}`;
 
     useEffect(() => {
-        if (block || !chainID) {
+        if (block !== latestBlock) {
+            setLatestBLock(block);
+            return;
+        }
+        if (!chainID) {
             return;
         }
 
@@ -39,10 +43,10 @@ export default function ChainNavbar({ chainID, block }: ChainNavbarProps) {
 
     return (
         <TabGroup>
-            <Tab to={`${chainURL}`} label="Info" extraMatchingRoutes={[`${chainURL}/contract`]} />
+            <Tab to={`${chainURL}`} label="Info" extraMatchingRoutes={[`${chainURL}/contract`]} exact={true} />
             <Tab to={`${chainURL}/accounts`} label="Accounts" />
             <Tab to={`${chainURL}/access-nodes`} label="Access nodes" />
-            <Tab to={`${chainURL}/blocks/${latestBlock}`} label="Block explorer" />
+            <Tab to={`${chainURL}/blocks/${latestBlock}`} label="Block explorer" exact={true} />
         </TabGroup>
     );
 }

--- a/src/app/components/Tab.tsx
+++ b/src/app/components/Tab.tsx
@@ -6,6 +6,7 @@ interface TabProps {
     to: string;
     label: string;
     extraMatchingRoutes?: string[];
+    exact?: boolean;
 }
 
 /**
@@ -13,12 +14,13 @@ interface TabProps {
  * @param props Tab props.
  * @param props.to Location to go to.
  * @param props.label The location label.
+ * @param props.exact If the route match must be exact or not.
  * @param props.extraMatchingRoutes Extra routes to mark this tab as active.
  * @returns The node to render.
  */
-const Tab: React.FC<TabProps> = ({ to, label, extraMatchingRoutes }) => {
+const Tab: React.FC<TabProps> = ({ exact, to, label, extraMatchingRoutes }) => {
     const location = useLocation();
-    const isActive = to === location.pathname;
+    const isActive = exact ? to === location.pathname : location.pathname.startsWith(to);
     const extraRoutesMatch = extraMatchingRoutes?.some(route => location.pathname.startsWith(route));
 
     return (
@@ -31,6 +33,7 @@ const Tab: React.FC<TabProps> = ({ to, label, extraMatchingRoutes }) => {
 };
 
 Tab.defaultProps = {
+    exact: false,
     extraMatchingRoutes: [],
 };
 

--- a/src/app/routes/Account.tsx
+++ b/src/app/routes/Account.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { ServiceFactory, WaspClientService, AssetsResponse } from "../../lib";
 import "./Route.scss";
-import { Breadcrumb, InfoBox, KeyValueRow } from "../components";
+import { Breadcrumb, ChainNavbar, InfoBox, KeyValueRow } from "../components";
 
 /**
  * Account panel.
@@ -11,10 +11,14 @@ import { Breadcrumb, InfoBox, KeyValueRow } from "../components";
 function Account() {
     const [accountBalance, setAccountBalance] = useState<AssetsResponse | null>(null);
     const { chainID, accountID } = useParams();
+
+    const chainURL = `/chains/${chainID}`;
     const blockBreadcrumbs = [
-        { goTo: `/chains/${chainID}`, text: `Chain ${chainID}` },
-        { goTo: `/chains/${chainID}/accounts/${accountID}`, text: `Account ${accountID}` },
+        { goTo: "/", text: "Home" },
+        { goTo: chainURL, text: `Chain ${chainID}` },
+        { goTo: `${chainURL}/accounts/${accountID}`, text: `Account ${accountID}` },
     ];
+
     React.useEffect(() => {
         if (!accountID || !chainID) {
             return;
@@ -39,6 +43,7 @@ function Account() {
                     <h2>Account {accountID}</h2>
                 </div>
                 <div className="content">
+                    <ChainNavbar chainID={chainID} />
                     <InfoBox title="Info">
                         <KeyValueRow keyText="Base Tokens" value={accountBalance?.baseTokens} />
                     </InfoBox>

--- a/src/app/routes/ChainBlockExplorer.tsx
+++ b/src/app/routes/ChainBlockExplorer.tsx
@@ -106,7 +106,7 @@ function ChainBlockExplorer() {
                     <h2 className="l1-details-title">Chain {chainID}</h2>
                 </div>
                 <div className="content">
-                    <ChainNavbar chainID={chainID} block={latestBlock} />
+                    <ChainNavbar chainID={chainID} block={blockIndex} />
                     <div className="middle row">
                         <h2>Block {blockID}</h2>
                     </div>


### PR DESCRIPTION
Closes https://github.com/iotaledger/wasp-dashboard/issues/304
# Description of change

Contracts: 
![image](https://user-images.githubusercontent.com/38158676/214544035-af0e842f-1b37-4479-b228-c5598e463e3a.png)

Block explorer:
![image](https://user-images.githubusercontent.com/38158676/214544083-8747f2b8-a3b0-444a-bae9-f81b9ec99431.png)

Accounts:
![image](https://user-images.githubusercontent.com/38158676/214543502-99187967-77dc-47c7-9a58-e4e20546386e.png)

## Type of change

- Bug fix

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code