### PR TITLE
fix: Close mobile menu when clicking in the menu links

### DIFF
--- a/src/app/components/MobileMenu.tsx
+++ b/src/app/components/MobileMenu.tsx
@@ -80,6 +80,7 @@ function MobileMenu(props: MenuProps) {
                         <React.Fragment key={b.label}>
                             {!b.hidden && b.route && (
                                 <Link
+                                    onClick={toggleMenu}
                                     to={b.route}
                                     className={classNames("mobile-panel-item", {
                                         "mobile-panel-item-selected":
@@ -88,9 +89,7 @@ function MobileMenu(props: MenuProps) {
                                     })}
                                 >
                                     {b.icon}
-                                    <span className="mobile-panel-item-label" onClick={toggleMenu}>
-                                        {b.label}
-                                    </span>
+                                    <span className="mobile-panel-item-label">{b.label}</span>
                                 </Link>
                             )}
                             {!b.hidden && b.function && (


### PR DESCRIPTION
# Description of change

Now, clicking in all the area of the button will close the mobile menu.

![image](https://user-images.githubusercontent.com/38158676/214800505-e368ad57-8a11-4aee-9d5f-10d0a90d3d44.png)


## Type of change

-  Bug fix

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code